### PR TITLE
Disable cookie-policy-banner for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "stylelint-config-standard-scss": "^6.1.0"
   },
   "dependencies": {
-    "@edx/frontend-component-cookie-policy-banner": "git+https://github.com/raccoongang/frontend-component-cookie-policy-banner#quince-rg",
     "@edx/paragon": "21.1.10",
     "@fortawesome/fontawesome-svg-core": "6.4.2",
     "@fortawesome/free-brands-svg-icons": "6.4.2",


### PR DESCRIPTION
We will enable it when either update tutor deployment for it or update the banner version.